### PR TITLE
Fixes #35: updated bindings for version downgrade feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,8 +59,8 @@ let package = Package(
 
         .target(name: "OpenTimelineIO_CXX",
             dependencies: ["OpenTime_CXX", "any", "optionallite"],
-            path: "OpenTimelineIO/src/OpenTimelineIO",
-            exclude: [ "CMakeLists.txt" ],
+            path: "OpenTimelineIO/src/opentimelineio",
+            exclude: [ "CMakeLists.txt", "CORE_VERSION_MAP.last.cpp" ],
             sources: ["."],
             publicHeadersPath: ".",
             cxxSettings: [

--- a/Sources/objc/include/opentimelineio.h
+++ b/Sources/objc/include/opentimelineio.h
@@ -44,9 +44,11 @@ void* otio_new_track();
 void* otio_new_transition();
 
 // MARK: SerializableObject
+
+typedef NSDictionary<NSString*, NSNumber*> schema_version_map;
     
-void serializable_object_to_json_file(CxxRetainer* self, NSString* filename, int indent, CxxErrorStruct* err);
-NSString* serializable_object_to_json_string(CxxRetainer* self, int indent, CxxErrorStruct* err);
+void serializable_object_to_json_file(CxxRetainer* self, NSString* filename, schema_version_map *target_family_label_spec, int indent, CxxErrorStruct* err);
+NSString* serializable_object_to_json_string(CxxRetainer* self, schema_version_map *target_family_label_spec, int indent, CxxErrorStruct* err);
     
 void* serializable_object_from_json_string(NSString* input, CxxErrorStruct* cxxErr);
 void* serializable_object_from_json_file(NSString* filename, CxxErrorStruct* cxxErr);

--- a/Sources/swift/SerializableObject.swift
+++ b/Sources/swift/SerializableObject.swift
@@ -7,6 +7,8 @@
 import OpenTimelineIO_objc
 typealias CxxSerializableObjectPtr = UnsafeMutableRawPointer
 
+public typealias schema_version_map = [String: NSNumber]
+
 public class SerializableObject: CxxRetainer {
     // MARK: - public API
     
@@ -22,16 +24,16 @@ public class SerializableObject: CxxRetainer {
         SerializableObject.wrapperCache.insert(key: cxxSerializableObject(), value: self)
     }
 
-    public func toJSON(url: URL, indent: Int = 4) throws {
-        return try toJSON(filename: url.path, indent: indent)
+    public func toJSON(url: URL, target_family_label_spec: schema_version_map = [:], indent: Int = 4) throws {
+        return try toJSON(filename: url.path,  target_family_label_spec: target_family_label_spec, indent: indent)
     }
 
-    public func toJSON(filename: String, indent: Int = 4) throws {
-        return try OTIOError.returnOrThrow { serializable_object_to_json_file(self, filename, Int32(indent), &$0) }
+    public func toJSON(filename: String, target_family_label_spec: schema_version_map = [:], indent: Int = 4) throws {
+        return try OTIOError.returnOrThrow { serializable_object_to_json_file(self, filename, target_family_label_spec, Int32(indent), &$0) }
     }
 
-    public func toJSON(indent: Int = 4) throws -> String {
-        return try OTIOError.returnOrThrow { serializable_object_to_json_string(self, Int32(indent), &$0) }
+    public func toJSON(target_family_label_spec: schema_version_map = [:], indent: Int = 4) throws -> String {
+        return try OTIOError.returnOrThrow { serializable_object_to_json_string(self, target_family_label_spec, Int32(indent), &$0) }
     }
     
     static public func fromJSON(url: URL) throws -> SerializableObject {


### PR DESCRIPTION
Fixes #35

**Summarize your change.**

I updated the bindings to include the new `target_family_label_spec` parameter introduced with this PR https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1387. This fixes the build issues we're currently encountering.