### PR TITLE
Use std::type_index for map index instead

### DIFF
--- a/Sources/objc/CxxAny.mm
+++ b/Sources/objc/CxxAny.mm
@@ -7,6 +7,7 @@
 
 #import "CxxAny.h"
 #import "CxxAnyDictionaryMutationStamp.h"
+#include <typeindex>
 #include <opentimelineio/stringUtils.h>
 #include <opentimelineio/serializableObject.h>
 
@@ -48,55 +49,55 @@ otio::any cxx_any_to_otio_any(CxxAny const& cxxAny) {
 
 namespace {
 struct _ToCxxAny {
-    std::map<std::type_info const*, std::function<void (otio::any const&, CxxAny*)>> function_map;
+    std::map<std::type_index, std::function<void (otio::any const&, CxxAny*)>> function_map;
     
     _ToCxxAny() {
         auto& m = function_map;
-        m[&typeid(void)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(void))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::NONE;
             
         };
-        m[&typeid(bool)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(bool))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::BOOL_;
             cxxAny->value.b = otio::any_cast<bool>(a);
         };
-        m[&typeid(int)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(int))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::INT;
             cxxAny->value.i = otio::any_cast<int>(a);
         };
-        m[&typeid(int64_t)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(int64_t))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::INT;
             cxxAny->value.i = otio::any_cast<int64_t>(a);
         };
-        m[&typeid(double)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(double))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::DOUBLE;
             cxxAny->value.d = otio::any_cast<double>(a);
         };
-        m[&typeid(std::string)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(std::string))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::STRING;
             cxxAny->value.s = otio::any_cast<std::string const&>(a).c_str();
         };
-        m[&typeid(otio::RationalTime)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::RationalTime))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::RATIONAL_TIME;
             cxxAny->value.rt = *((CxxRationalTime*)&otio::any_cast<otio::RationalTime const&>(a));
         };
-        m[&typeid(otio::TimeRange)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::TimeRange))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::TIME_RANGE;
             cxxAny->value.tr = *((CxxTimeRange*)&otio::any_cast<otio::TimeRange const&>(a));
         };
-        m[&typeid(otio::TimeTransform)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::TimeTransform))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::TIME_TRANSFORM;
             cxxAny->value.tt = *((CxxTimeTransform*)&otio::any_cast<otio::TimeTransform const&>(a));
         };
-        m[&typeid(otio::SerializableObject::Retainer<>)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::SerializableObject::Retainer<>))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::SERIALIZABLE_OBJECT;
             cxxAny->value.ptr = otio::any_cast<otio::SerializableObject::Retainer<> const&>(a).value;
         };
-        m[&typeid(otio::AnyVector)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::AnyVector))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::VECTOR;
             cxxAny->value.ptr = (void*) &otio::any_cast<otio::AnyVector const&>(a);
         };
-        m[&typeid(otio::AnyDictionary)] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::AnyDictionary))] = [](otio::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::DICTIONARY;
             cxxAny->value.ptr = (void*) &otio::any_cast<otio::AnyDictionary const&>(a);
         };
@@ -106,7 +107,7 @@ struct _ToCxxAny {
 
 void otio_any_to_cxx_any(otio::any const& a, CxxAny* cxxAny) {
     static auto toCxxAny = _ToCxxAny();
-    auto e = toCxxAny.function_map.find(&a.type());
+    auto e = toCxxAny.function_map.find(std::type_index(a.type()));
     
     if (e != toCxxAny.function_map.end()) {
         e->second(a, cxxAny);

--- a/Tests/OpenTimelineIOTests/testTimeline.swift
+++ b/Tests/OpenTimelineIOTests/testTimeline.swift
@@ -1,0 +1,53 @@
+//
+//  testTimeline.swift
+//  
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+import XCTest
+@testable import OpenTimelineIO
+
+import Foundation
+
+final class testTimeline: XCTestCase {
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func testMetadataRead() {
+        let inputName = "data/timeline.otio"
+        let knownDictKey = "foo"
+        let knownKey = "some_key"
+        let knownValue = "some_value"
+        
+        guard let timelineInputPath = Bundle.module.path(forResource: inputName, ofType: "") else {
+            XCTFail("Missing test data `\(inputName)`")
+            return
+        }
+
+        do {
+            let otio = try SerializableObject.fromJSON(filename: timelineInputPath)
+            
+            guard let timeline = otio as? Timeline else {
+                XCTFail("Could not create Timeline object from \(timelineInputPath)")
+                return
+            }
+
+            let timelineMetadata = timeline.metadata
+
+            if let knownMetadata = timelineMetadata[knownDictKey] as? Metadata.Dictionary {
+                if let value = knownMetadata[knownKey] as? String {
+                    XCTAssertTrue(value == knownValue)
+                } else {
+                    XCTFail("Expects (\(knownKey), \(knownValue)), but found none in \(knownMetadata)")
+                }
+            } else {
+                XCTFail("Cannot read timeline metadata \(String(describing: timelineMetadata[knownDictKey])) as `Metadata.Dictionary`")
+            }
+        } catch let error {
+            XCTFail("Cannot read OTIO file `\(timelineInputPath)`: \(error)")
+        }
+    }
+}

--- a/Tests/data/timeline.otio
+++ b/Tests/data/timeline.otio
@@ -1,0 +1,38 @@
+{
+    "OTIO_SCHEMA": "Timeline.1",
+    "metadata": {
+        "foo": {
+            "some_key": "some_value"
+        }
+    },
+    "name": "Timeline_AAF.Exported.01",
+    "global_start_time": {
+        "OTIO_SCHEMA": "RationalTime.1",
+        "rate": 24.0,
+        "value": 105733.0
+    },
+    "tracks": {
+        "OTIO_SCHEMA": "Stack.1",
+        "metadata": {},
+        "name": "tracks",
+        "source_range": null,
+        "effects": [],
+        "markers": [],
+        "enabled": true,
+        "children": [
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "some_key": "some_value"
+                },
+                "name": "Sequence",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [],
+                "kind": "Video"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This change fixes the issue that an `AnyDictionary` in `metadata` cannot be match to any entry in the `function_map` in Apple Silicon (ARM) build, because typeid() returns different addresses for `AnyDictionary`.

It ends up being unknown and values cannot be read in the application code.

Without the fix, the test case fails in Xcode, even though `swift test` doesn't fail from the command line.