### PR TITLE
Recommend using HTTPS instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ from the command line easily as well:
 ====================
 
 Use the Package Manager in Xcode and bring in
-  `git@github.com:OpenTimelineIO/OpenTimelineIO-Swift-Bindings.git`
+  `https://github.com/OpenTimelineIO/OpenTimelineIO-Swift-Bindings.git`
 
 You should see a choice of two C++ products that can be added to your workspace;
 for Swift development, choose the third product named `OpenTimelineIO`.


### PR DESCRIPTION
This PR updates the instructions for adding this package to an Xcode project, preferring HTTPS instead of SSH. Based on developer feedback, using HTTPS is more reliable.
