### PR TITLE
Feature/v0.17.0 - AWSF Dev Days 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -65,6 +65,7 @@ let package = Package(
             publicHeadersPath: ".",
             cxxSettings: [
                 .headerSearchPath("."),
+                .headerSearchPath("../deps/any/"),
                 .headerSearchPath("../deps/Imath/src/Imath"),
                 .headerSearchPath("../../../Sources/cpp"),
                 .headerSearchPath("../deps/rapidjson/include")]),
@@ -93,5 +94,5 @@ let package = Package(
             sources: ["OpenTimelineIOTests"],
             resources: [ .copy("data") ])
     ],
-    cxxLanguageStandard: CXXLanguageStandard.cxx14
+    cxxLanguageStandard: CXXLanguageStandard.cxx17
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
     platforms: [.macOS(.v10_13),
         .iOS(.v11)],
     products: [
-        .library(name: "any", targets: ["any"]),
         .library(name: "OpenTime_CXX", targets: ["OpenTime_CXX"]),
         .library(name: "OpenTimelineIO_CXX", targets: ["OpenTimelineIO_CXX"]),
         .library(name: "OpenTimelineIO", targets: ["OpenTimelineIO"])
@@ -19,33 +18,12 @@ let package = Package(
 
     dependencies: [],
     targets: [
-        .target(name: "any",
-            path: ".",
-            exclude: [
-                "CONTRIBUTORS.md", "NOTICE.txt", "CONTRIBUTING.md", "LICENSE.txt", "CODE_OF_CONDUCT.md",
-                "OTIO_CLA_Corporate.pdf", "OTIO_CLA_Individual.pdf",
-                "README.md", "Sources/shims/optionallite-shim.cpp", "Sources/shims/otio_header_root-shim.cpp",
-                "Examples", "OpenTimelineIO", "Tests", "Sources/objc", "Sources/swift"],
-            sources: ["Sources/shims/any-shim.cpp"],
-            publicHeadersPath:"OpenTimelineIO/src/deps"),
-
-        .target(name: "optionallite",
-            path: ".",
-            exclude: [
-                "CONTRIBUTORS.md", "NOTICE.txt", "CONTRIBUTING.md", "LICENSE.txt", "CODE_OF_CONDUCT.md",
-                "OTIO_CLA_Corporate.pdf", "OTIO_CLA_Individual.pdf",
-                "README.md", "Sources/shims/any-shim.cpp", "Sources/shims/otio_header_root-shim.cpp",
-                "Examples", "OpenTimelineIO", "Tests", "Sources/objc", "Sources/swift"],
-            sources: ["Sources/shims/optionallite-shim.cpp"],
-            publicHeadersPath:"OpenTimelineIO/src/deps/optional-lite/include"),
-
         .target(name: "otio_header_root",
             path: ".",
             exclude: [
                 "CONTRIBUTORS.md", "NOTICE.txt", "CONTRIBUTING.md", "LICENSE.txt", "CODE_OF_CONDUCT.md",
                 "OTIO_CLA_Corporate.pdf", "OTIO_CLA_Individual.pdf",
-                "README.md", "Sources/shims/any-shim.cpp", "Sources/shims/optionallite-shim.cpp",
-                "Examples", "OpenTimelineIO", "Tests", "Sources/objc", "Sources/swift"],
+                "README.md", "Examples", "OpenTimelineIO", "Tests", "Sources/objc", "Sources/swift"],
             sources: ["Sources/shims/otio_header_root-shim.cpp"],
             publicHeadersPath:"OpenTimelineIO/src"),
 
@@ -58,7 +36,7 @@ let package = Package(
             cxxSettings: [ .headerSearchPath(".")]),
 
         .target(name: "OpenTimelineIO_CXX",
-            dependencies: ["OpenTime_CXX", "any", "optionallite"],
+            dependencies: ["OpenTime_CXX"],
             path: "OpenTimelineIO/src/opentimelineio",
             exclude: ["CMakeLists.txt", "CORE_VERSION_MAP.last.cpp", "OpenTimelineIOConfig.cmake.in"],
             sources: ["."],

--- a/Sources/objc/CxxAny.mm
+++ b/Sources/objc/CxxAny.mm
@@ -11,37 +11,37 @@
 #include <opentimelineio/stringUtils.h>
 #include <opentimelineio/serializableObject.h>
 
-otio::any cxx_any_to_otio_any(CxxAny const& cxxAny) {
+std::any cxx_any_to_otio_any(CxxAny const& cxxAny) {
     switch(cxxAny.type_code) {
         case CxxAny::NONE:
-            return otio::any();
+            return std::any();
         case CxxAny::BOOL_:
-            return otio::any(cxxAny.value.b);
+            return std::any(cxxAny.value.b);
         case CxxAny::INT:
             if (cxxAny.value.i < -INT_MIN || cxxAny.value.i > INT_MAX) {
-                return otio::any(cxxAny.value.i);
+                return std::any(cxxAny.value.i);
             }
             else {
-                return otio::any(int(cxxAny.value.i));
+                return std::any(int(cxxAny.value.i));
             }
         case CxxAny::DOUBLE:
-            return otio::any(cxxAny.value.d);
+            return std::any(cxxAny.value.d);
         case CxxAny::STRING:
-            return otio::any(std::string(cxxAny.value.s));
+            return std::any(std::string(cxxAny.value.s));
         case CxxAny::SERIALIZABLE_OBJECT:
             { auto so = reinterpret_cast<otio::SerializableObject*>(cxxAny.value.ptr);
-              return otio::any(otio::SerializableObject::Retainer<>(so));
+              return std::any(otio::SerializableObject::Retainer<>(so));
             }
         case CxxAny::RATIONAL_TIME:
-            return otio::any(*((otio::RationalTime const*)(&cxxAny.value.rt)));
+            return std::any(*((otio::RationalTime const*)(&cxxAny.value.rt)));
         case CxxAny::TIME_RANGE:
-            return otio::any(*((otio::TimeRange const*)(&cxxAny.value.tr)));
+            return std::any(*((otio::TimeRange const*)(&cxxAny.value.tr)));
         case CxxAny::TIME_TRANSFORM:
-             return otio::any(*((otio::TimeTransform const*)(&cxxAny.value.tt)));
+             return std::any(*((otio::TimeTransform const*)(&cxxAny.value.tt)));
         case CxxAny::VECTOR:
-             return otio::any(*reinterpret_cast<otio::AnyVector*>(cxxAny.value.ptr));
+             return std::any(*reinterpret_cast<otio::AnyVector*>(cxxAny.value.ptr));
         case CxxAny::DICTIONARY:
-            return otio::any(*reinterpret_cast<otio::AnyDictionary*>(cxxAny.value.ptr));
+            return std::any(*reinterpret_cast<otio::AnyDictionary*>(cxxAny.value.ptr));
         default:
             return otio::SerializableObject::UnknownType { opentime::string_printf("%s <Swift Type>", cxxAny.value.s) };
     }
@@ -49,63 +49,63 @@ otio::any cxx_any_to_otio_any(CxxAny const& cxxAny) {
 
 namespace {
 struct _ToCxxAny {
-    std::map<std::type_index, std::function<void (otio::any const&, CxxAny*)>> function_map;
+    std::map<std::type_index, std::function<void (std::any const&, CxxAny*)>> function_map;
     
     _ToCxxAny() {
         auto& m = function_map;
-        m[std::type_index(typeid(void))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(void))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::NONE;
             
         };
-        m[std::type_index(typeid(bool))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(bool))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::BOOL_;
-            cxxAny->value.b = otio::any_cast<bool>(a);
+            cxxAny->value.b = std::any_cast<bool>(a);
         };
-        m[std::type_index(typeid(int))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(int))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::INT;
-            cxxAny->value.i = otio::any_cast<int>(a);
+            cxxAny->value.i = std::any_cast<int>(a);
         };
-        m[std::type_index(typeid(int64_t))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(int64_t))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::INT;
-            cxxAny->value.i = otio::any_cast<int64_t>(a);
+            cxxAny->value.i = std::any_cast<int64_t>(a);
         };
-        m[std::type_index(typeid(double))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(double))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::DOUBLE;
-            cxxAny->value.d = otio::any_cast<double>(a);
+            cxxAny->value.d = std::any_cast<double>(a);
         };
-        m[std::type_index(typeid(std::string))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(std::string))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::STRING;
-            cxxAny->value.s = otio::any_cast<std::string const&>(a).c_str();
+            cxxAny->value.s = std::any_cast<std::string const&>(a).c_str();
         };
-        m[std::type_index(typeid(otio::RationalTime))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::RationalTime))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::RATIONAL_TIME;
-            cxxAny->value.rt = *((CxxRationalTime*)&otio::any_cast<otio::RationalTime const&>(a));
+            cxxAny->value.rt = *((CxxRationalTime*)&std::any_cast<otio::RationalTime const&>(a));
         };
-        m[std::type_index(typeid(otio::TimeRange))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::TimeRange))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::TIME_RANGE;
-            cxxAny->value.tr = *((CxxTimeRange*)&otio::any_cast<otio::TimeRange const&>(a));
+            cxxAny->value.tr = *((CxxTimeRange*)&std::any_cast<otio::TimeRange const&>(a));
         };
-        m[std::type_index(typeid(otio::TimeTransform))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::TimeTransform))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::TIME_TRANSFORM;
-            cxxAny->value.tt = *((CxxTimeTransform*)&otio::any_cast<otio::TimeTransform const&>(a));
+            cxxAny->value.tt = *((CxxTimeTransform*)&std::any_cast<otio::TimeTransform const&>(a));
         };
-        m[std::type_index(typeid(otio::SerializableObject::Retainer<>))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::SerializableObject::Retainer<>))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::SERIALIZABLE_OBJECT;
-            cxxAny->value.ptr = otio::any_cast<otio::SerializableObject::Retainer<> const&>(a).value;
+            cxxAny->value.ptr = std::any_cast<otio::SerializableObject::Retainer<> const&>(a).value;
         };
-        m[std::type_index(typeid(otio::AnyVector))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::AnyVector))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::VECTOR;
-            cxxAny->value.ptr = (void*) &otio::any_cast<otio::AnyVector const&>(a);
+            cxxAny->value.ptr = (void*) &std::any_cast<otio::AnyVector const&>(a);
         };
-        m[std::type_index(typeid(otio::AnyDictionary))] = [](otio::any const& a, CxxAny* cxxAny) {
+        m[std::type_index(typeid(otio::AnyDictionary))] = [](std::any const& a, CxxAny* cxxAny) {
             cxxAny->type_code = CxxAny::DICTIONARY;
-            cxxAny->value.ptr = (void*) &otio::any_cast<otio::AnyDictionary const&>(a);
+            cxxAny->value.ptr = (void*) &std::any_cast<otio::AnyDictionary const&>(a);
         };
     }
 };
 }
 
-void otio_any_to_cxx_any(otio::any const& a, CxxAny* cxxAny) {
+void otio_any_to_cxx_any(std::any const& a, CxxAny* cxxAny) {
     static auto toCxxAny = _ToCxxAny();
     auto e = toCxxAny.function_map.find(std::type_index(a.type()));
     

--- a/Sources/objc/CxxAnyDictionaryIterator.mm
+++ b/Sources/objc/CxxAnyDictionaryIterator.mm
@@ -14,7 +14,7 @@ static bool lookup(CxxAnyDictionaryIterator* dictionaryIterator, T* result) {
         if (auto dict = ms->any_dictionary) {
             if (dictionaryIterator.iterator != dict->end()) {
                 if (dictionaryIterator.iterator->second.type() == typeid(T)) {
-                    *result = otio::any_cast<T>(dictionaryIterator.iterator->second);
+                    *result = std::any_cast<T>(dictionaryIterator.iterator->second);
                     return true;
                 }
             }
@@ -90,7 +90,7 @@ static bool lookup(CxxAnyDictionaryIterator* dictionaryIterator, T* result) {
     if (ms->stamp == self.startingStamp) {
         if (auto dict = ms->any_dictionary) {
             if (self.iterator != dict->end()) {
-                otio::any a = cxx_any_to_otio_any(cxxAny);
+                std::any a = cxx_any_to_otio_any(cxxAny);
                 std::swap(self.iterator->second, a);
             }
         }

--- a/Sources/objc/CxxAnyDictionaryMutationStamp.mm
+++ b/Sources/objc/CxxAnyDictionaryMutationStamp.mm
@@ -19,7 +19,7 @@ static bool lookup(otio::AnyDictionary::MutationStamp* mutationStamp, NSString* 
         auto it = dict->find(std::string(key.UTF8String));
         if (it != dict->end()) {
             if (it->second.type() == typeid(T)) {
-                *result = otio::any_cast<T>(it->second);
+                *result = std::any_cast<T>(it->second);
                 return true;
             }
         }
@@ -73,7 +73,7 @@ static bool lookup(otio::AnyDictionary::MutationStamp* mutationStamp, NSString* 
         auto skey = std::string(key.UTF8String);
         auto it = dict->find(skey);
         if (it != dict->end()) {
-            otio::any a = cxx_any_to_otio_any(cxxAny);
+            std::any a = cxx_any_to_otio_any(cxxAny);
             std::swap(it->second, a);
         }
         else {

--- a/Sources/objc/CxxAnyVectorMutationStamp.mm
+++ b/Sources/objc/CxxAnyVectorMutationStamp.mm
@@ -18,7 +18,7 @@ static bool lookup(otio::AnyVector::MutationStamp* mutationStamp, int index, T* 
     if (auto v = mutationStamp->any_vector) {
         if (index < v->size()) {
             if ((*v)[index].type() == typeid(T)) {
-                *result = otio::any_cast<T>(v[index]);
+                *result = std::any_cast<T>(v[index]);
                 return true;
             }
         }
@@ -67,7 +67,7 @@ static bool lookup(otio::AnyVector::MutationStamp* mutationStamp, int index, T* 
            value:(CxxAny) cxxAny {
     if (auto v = self.mutationStamp->any_vector) {
         if (index >= 0 && index < v->size()) {
-            otio::any a = cxx_any_to_otio_any(cxxAny);
+            std::any a = cxx_any_to_otio_any(cxxAny);
             std::swap((*v)[index], a);
         }
         else {
@@ -94,7 +94,7 @@ static bool lookup(otio::AnyVector::MutationStamp* mutationStamp, int index, T* 
     if (auto v = self.mutationStamp->any_vector) {
         if (grow) {
             for (int i = 0; i < n; i++) {
-                v->push_back(otio::any());
+                v->push_back(std::any());
             }
         }
         else {

--- a/Sources/objc/include/CxxAny.h
+++ b/Sources/objc/include/CxxAny.h
@@ -7,13 +7,6 @@
 
 #import "opentime.h"
 
-#if defined(__cplusplus)
-#import <any/any.hpp>
-#import "opentimelineio.h"
-namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
-#endif
-
-
 typedef union CxxAnyValue {
     bool b;
     int64_t i;
@@ -46,6 +39,7 @@ typedef struct CxxAny {
 } CxxAny;
 
 #if defined(__cplusplus)
+#import <any>
 void otio_any_to_cxx_any(std::any const&, CxxAny*);
 std::any cxx_any_to_otio_any(CxxAny const&);
 #endif

--- a/Sources/objc/include/CxxAny.h
+++ b/Sources/objc/include/CxxAny.h
@@ -8,7 +8,8 @@
 #import "opentime.h"
 
 #if defined(__cplusplus)
-#import <opentimelineio/any.h>
+#import <any/any.hpp>
+#import "opentimelineio.h"
 namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
 #endif
 
@@ -45,6 +46,6 @@ typedef struct CxxAny {
 } CxxAny;
 
 #if defined(__cplusplus)
-void otio_any_to_cxx_any(otio::any const&, CxxAny*);
-otio::any cxx_any_to_otio_any(CxxAny const&);
+void otio_any_to_cxx_any(std::any const&, CxxAny*);
+std::any cxx_any_to_otio_any(CxxAny const&);
 #endif

--- a/Sources/objc/include/CxxAnyDictionaryIterator.h
+++ b/Sources/objc/include/CxxAnyDictionaryIterator.h
@@ -6,6 +6,7 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #import <Foundation/Foundation.h>
+#import "CxxAny.h"
 #import "opentime.h"
 #import "CxxAnyDictionaryMutationStamp.h"
 

--- a/Sources/objc/opentimelineio.mm
+++ b/Sources/objc/opentimelineio.mm
@@ -357,7 +357,7 @@ void item_set_source_range(CxxRetainer* self , CxxTimeRange tr) {
 
 void item_set_source_range_to_null(CxxRetainer* self) {
     auto item = SO_cast<otio::Item>(self);
-    item->set_source_range(otio::optional<otio::TimeRange>());
+    item->set_source_range(std::optional<otio::TimeRange>());
 }
 
 CxxTimeRange item_available_range(CxxRetainer* self, CxxErrorStruct* cxxErr) {
@@ -628,7 +628,7 @@ void media_reference_set_available_range(CxxRetainer* self, CxxTimeRange tr) {
 }
 
 void media_reference_clear_available_range(CxxRetainer* self) {
-    SO_cast<otio::MediaReference>(self)->set_available_range(otio::nullopt);
+    SO_cast<otio::MediaReference>(self)->set_available_range(std::nullopt);
 }
 
 // MARK: - Timeline
@@ -655,7 +655,7 @@ void timeline_set_global_start_time(CxxRetainer* self, CxxRationalTime rt) {
 }
 
 void timeline_clear_global_start_time(CxxRetainer* self) {
-    SO_cast<otio::Timeline>(self)->set_global_start_time(otio::nullopt);
+    SO_cast<otio::Timeline>(self)->set_global_start_time(std::nullopt);
 }
 
 CxxRationalTime timeline_duration(CxxRetainer* self, CxxErrorStruct* cxxErr) {

--- a/Sources/shims/any-shim.cpp
+++ b/Sources/shims/any-shim.cpp
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright Contributors to the OpenTimelineIO project
-//
-// This file exists only to placate the Swift Package Manager,
-// and has no other functional purpose.
-
-static int unused_any_dummy = -1;

--- a/Sources/shims/optionallite-shim.cpp
+++ b/Sources/shims/optionallite-shim.cpp
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright Contributors to the OpenTimelineIO project
-//
-// This file exists only to placate the Swift Package Manager,
-// and has no other functional purpose.
-
-static int unused_optional_dummy = -1;


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

```Fixes #58```

**Summarize your change.**

This PR updates the Swift Bindings package to support OTIO v0.17.0

For Reviewers: Please note that this change introduces some minor changes to support OTIO's migration from `otio::any` to `std::any` as per similar changes in https://github.com/OpenTimelineIO/raven/pull/46

To support `std::any` we also needed to update the Swift Package version to 5.5 (perhaps 5.4 is the minimal?) and update the cxx version, as well as change some search paths in the Package Definition.

We also had some changes to the Obj-C / C++ bridging code which references `otio:any` , as well as `otio::optional` and `otio::nullopt` to their std counterparts. 

We also remove the `any` and `optional lite` package libraries, shim code, and references since we no longer need them 

We presume things are working as `swift test` passes completely. We include no new tests as we aren't changing functionality on the exposed swift or otio api surface area.

Thank you!

