### PR TITLE
Support swift 5.9 with minimum 5.5 compatibility.

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -8,11 +8,8 @@ import PackageDescription
 
 let package = Package(
     name: "OpenTimelineIO",
-    platforms: [
-      .macOS(.v10_13),
-      .iOS(.v12),
-      .visionOS(.v1)
-    ],
+    platforms: [.macOS(.v10_13),
+        .iOS(.v11)],
     products: [
         .library(name: "OpenTime_CXX", targets: ["OpenTime_CXX"]),
         .library(name: "OpenTimelineIO_CXX", targets: ["OpenTimelineIO_CXX"]),


### PR DESCRIPTION
**Summarize your change.**

Support Swift 5.9, **visionOS** 1.0+, and a minimum **iOS** version of 12.

Add a list of changes, and note any that might need special attention during review.

- Created a new Swift Package manifest for backwards compatibility with Swift 5.5 and older.
- Bumped the existing Swift Package manifest to support a minimum of Swift 5.9 (the minimum required for Swift/C++ interop), **visionOS** 1.0 and later, and a minimum **iOS** version of 12.

**Reference associated tests.**

- All tests pass.

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html
-->
