### PR TITLE
Add ImageSequenceReference Support

### DIFF
--- a/Sources/objc/include/opentimelineio.h
+++ b/Sources/objc/include/opentimelineio.h
@@ -29,6 +29,7 @@ void* otio_new_external_reference();
 void* otio_new_freeze_frame();
 void* otio_new_gap();
 void* otio_new_generator_reference();
+void* otio_new_image_sequence_reference();
 void* otio_new_item();
 void* otio_new_linear_time_warp();
 void* otio_new_marker();
@@ -97,6 +98,29 @@ void effect_set_name(CxxRetainer* self, NSString*);
 // MARK: - ExternalReference
 NSString* external_reference_get_target_url(CxxRetainer* self);
 void external_reference_set_target_url(CxxRetainer* self, NSString*);
+
+// MARK: - ImageSequenceReference
+NSString* image_sequence_reference_get_target_url_base(CxxRetainer* self);
+void image_sequence_reference_set_target_url_base(CxxRetainer* self, NSString*);
+NSString* image_sequence_reference_get_name_prefix(CxxRetainer* self);
+void image_sequence_reference_set_name_prefix(CxxRetainer* self, NSString*);
+NSString* image_sequence_reference_get_name_suffix(CxxRetainer* self);
+void image_sequence_reference_set_name_suffix(CxxRetainer* self, NSString*);
+int image_sequence_reference_get_start_frame(CxxRetainer* self);
+void image_sequence_reference_set_start_frame(CxxRetainer* self, int start_frame);
+int image_sequence_reference_get_frame_step(CxxRetainer* self);
+void image_sequence_reference_set_frame_step(CxxRetainer* self, int frame_step);
+double image_sequence_reference_get_rate(CxxRetainer* self);
+void image_sequence_reference_set_rate(CxxRetainer* self, double rate);
+int image_sequence_reference_get_frame_zero_padding(CxxRetainer* self);
+void image_sequence_reference_set_frame_zero_padding(CxxRetainer* self, int frame_zero_padding);
+int image_sequence_reference_get_missing_frame_policy(CxxRetainer* self);
+void image_sequence_reference_set_missing_frame_policy(CxxRetainer* self, int missing_frame_policy);
+int image_sequence_reference_end_frame(CxxRetainer* self);
+int image_sequence_reference_number_of_images_in_sequence(CxxRetainer* self);
+int image_sequence_reference_frame_for_time(CxxRetainer* self, CxxRationalTime, CxxErrorStruct*);
+NSString* image_sequence_reference_target_url_for_image_number(CxxRetainer* self, int image_number, CxxErrorStruct*);
+CxxRationalTime image_sequence_reference_presentation_time_for_image_number(CxxRetainer* self, int image_number, CxxErrorStruct*);
 
 // MARK: - GeneratorReference
 NSString* generator_reference_get_generator_kind(CxxRetainer* self);

--- a/Sources/objc/opentimelineio.mm
+++ b/Sources/objc/opentimelineio.mm
@@ -14,6 +14,7 @@
 #include <opentimelineio/freezeFrame.h>
 #include <opentimelineio/gap.h>
 #include <opentimelineio/generatorReference.h>
+#include <opentimelineio/imageSequenceReference.h>
 #include <opentimelineio/item.h>
 #include <opentimelineio/linearTimeWarp.h>
 #include <opentimelineio/marker.h>
@@ -141,6 +142,10 @@ void* otio_new_gap() {
 
 void* otio_new_generator_reference() {
     return new otio::GeneratorReference;
+}
+
+void* otio_new_image_sequence_reference() {
+    return new otio::ImageSequenceReference;
 }
 
 void* otio_new_item() {
@@ -772,6 +777,94 @@ NSString* external_reference_get_target_url(CxxRetainer* self) {
  
 void external_reference_set_target_url(CxxRetainer* self, NSString* target_url) {
     SO_cast<otio::ExternalReference>(self)->set_target_url([target_url UTF8String]);
+}
+
+// MARK: - ImageSequenceReference
+NSString* image_sequence_reference_get_target_url_base(CxxRetainer* self) {
+    return make_nsstring(SO_cast<otio::ImageSequenceReference>(self)->target_url_base());
+}
+
+void image_sequence_reference_set_target_url_base(CxxRetainer* self, NSString* target_url_base) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_target_url_base([target_url_base UTF8String]);
+}
+
+NSString* image_sequence_reference_get_name_prefix(CxxRetainer* self) {
+    return make_nsstring(SO_cast<otio::ImageSequenceReference>(self)->name_prefix());
+}
+
+void image_sequence_reference_set_name_prefix(CxxRetainer* self, NSString* name_prefix) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_name_prefix([name_prefix UTF8String]);
+}
+
+NSString* image_sequence_reference_get_name_suffix(CxxRetainer* self) {
+    return make_nsstring(SO_cast<otio::ImageSequenceReference>(self)->name_suffix());
+}
+
+void image_sequence_reference_set_name_suffix(CxxRetainer* self, NSString* name_suffix) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_name_suffix([name_suffix UTF8String]);
+}
+
+int image_sequence_reference_get_start_frame(CxxRetainer* self) {
+    return SO_cast<otio::ImageSequenceReference>(self)->start_frame();
+}
+
+void image_sequence_reference_set_start_frame(CxxRetainer* self, int start_frame) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_start_frame(start_frame);
+}
+
+int image_sequence_reference_get_frame_step(CxxRetainer* self) {
+    return SO_cast<otio::ImageSequenceReference>(self)->frame_step();
+}
+
+void image_sequence_reference_set_frame_step(CxxRetainer* self, int frame_step) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_frame_step(frame_step);
+}
+
+double image_sequence_reference_get_rate(CxxRetainer* self) {
+    return SO_cast<otio::ImageSequenceReference>(self)->rate();
+}
+
+void image_sequence_reference_set_rate(CxxRetainer* self, double rate) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_rate(rate);
+}
+
+int image_sequence_reference_get_frame_zero_padding(CxxRetainer* self) {
+    return SO_cast<otio::ImageSequenceReference>(self)->frame_zero_padding();
+}
+
+void image_sequence_reference_set_frame_zero_padding(CxxRetainer* self, int frame_zero_padding) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_frame_zero_padding(frame_zero_padding);
+}
+
+int image_sequence_reference_get_missing_frame_policy(CxxRetainer* self) {
+    return SO_cast<otio::ImageSequenceReference>(self)->missing_frame_policy();
+}
+
+void image_sequence_reference_set_missing_frame_policy(CxxRetainer* self, int missing_frame_policy) {
+    SO_cast<otio::ImageSequenceReference>(self)->set_missing_frame_policy(otio::ImageSequenceReference::MissingFramePolicy(missing_frame_policy));
+}
+
+int image_sequence_reference_end_frame(CxxRetainer* self) {
+    return SO_cast<otio::ImageSequenceReference>(self)->end_frame();
+}
+
+int image_sequence_reference_number_of_images_in_sequence(CxxRetainer* self) {
+    return SO_cast<otio::ImageSequenceReference>(self)->number_of_images_in_sequence();
+}
+
+int image_sequence_reference_frame_for_time(CxxRetainer* self, CxxRationalTime time, CxxErrorStruct* cxxErr) {
+    _AutoErrorHandler aeh(cxxErr);
+    return SO_cast<otio::ImageSequenceReference>(self)->frame_for_time(otioRationalTime(time), &aeh.error_status);
+}
+
+NSString* image_sequence_reference_target_url_for_image_number(CxxRetainer* self, int image_number, CxxErrorStruct* cxxErr) {
+    _AutoErrorHandler aeh(cxxErr);
+    return make_nsstring(SO_cast<otio::ImageSequenceReference>(self)->target_url_for_image_number(image_number, &aeh.error_status));
+}
+
+CxxRationalTime image_sequence_reference_presentation_time_for_image_number(CxxRetainer* self, int image_number, CxxErrorStruct* cxxErr) {
+    _AutoErrorHandler aeh(cxxErr);
+    return cxxRationalTime(SO_cast<otio::ImageSequenceReference>(self)->presentation_time_for_image_number(image_number, &aeh.error_status));
 }
 
 // MARK: - GeneratorReference

--- a/Sources/swift/ImageSequenceReference.swift
+++ b/Sources/swift/ImageSequenceReference.swift
@@ -1,0 +1,130 @@
+//
+//  ImageSequenceReference.swift
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+import Foundation
+import OpenTimelineIO_objc
+
+public class ImageSequenceReference : MediaReference {
+    override public init() {
+        super.init(otio_new_image_sequence_reference())
+    }
+
+    public enum MissingFramePolicy: Int {
+        case error = 0
+        case hold = 1
+        case black = 2
+    }
+
+    public convenience init<ST : Sequence>(targetURLBase: String? = nil,
+                                           namePrefix: String? = nil,
+                                           nameSuffix: String? = nil,
+                                           startFrame: Int = 1,
+                                           frameStep: Int = 1,
+                                           rate: Double = 1,
+                                           frameZeroPadding: Int = 0,
+                                           missingFramePolicy: MissingFramePolicy = .error,
+                                           availableRange: TimeRange? = nil,
+                                           metadata: ST? = nil) where ST.Element == Metadata.Dictionary.Element {
+        self.init()
+        metadataInit(name, metadata)
+        if let targetURLBase = targetURLBase {
+            self.targetURLBase = targetURLBase
+        }
+        if let namePrefix = namePrefix {
+            self.namePrefix = namePrefix
+        }
+        if let nameSuffix = nameSuffix {
+            self.nameSuffix = nameSuffix
+        }
+        self.startFrame = startFrame
+        self.frameStep = frameStep
+        self.rate = rate
+        self.frameZeroPadding = frameZeroPadding
+        self.missingFramePolicy = missingFramePolicy
+        if let availableRange = availableRange {
+            self.availableRange = availableRange
+        }
+    }
+
+    public convenience init(targetURLBase: String? = nil,
+                            namePrefix: String? = nil,
+                            nameSuffix: String? = nil,
+                            startFrame: Int = 1,
+                            frameStep: Int = 1,
+                            rate: Double = 1,
+                            frameZeroPadding: Int = 0,
+                            missingFramePolicy: MissingFramePolicy = .error,
+                            availableRange: TimeRange? = nil) {
+        self.init(targetURLBase: targetURLBase, namePrefix: namePrefix, nameSuffix: nameSuffix,
+                  startFrame: startFrame, frameStep: frameStep, rate: rate,
+                  frameZeroPadding: frameZeroPadding, missingFramePolicy: missingFramePolicy,
+                  availableRange: availableRange, metadata: Metadata.Dictionary.none)
+    }
+
+    public var targetURLBase: String {
+        get { return image_sequence_reference_get_target_url_base(self) }
+        set { image_sequence_reference_set_target_url_base(self, newValue) }
+    }
+
+    public var namePrefix: String {
+        get { return image_sequence_reference_get_name_prefix(self) }
+        set { image_sequence_reference_set_name_prefix(self, newValue) }
+    }
+
+    public var nameSuffix: String {
+        get { return image_sequence_reference_get_name_suffix(self) }
+        set { image_sequence_reference_set_name_suffix(self, newValue) }
+    }
+
+    public var startFrame: Int {
+        get { return Int(image_sequence_reference_get_start_frame(self)) }
+        set { image_sequence_reference_set_start_frame(self, Int32(newValue)) }
+    }
+
+    public var frameStep: Int {
+        get { return Int(image_sequence_reference_get_frame_step(self)) }
+        set { image_sequence_reference_set_frame_step(self, Int32(newValue)) }
+    }
+
+    public var rate: Double {
+        get { return image_sequence_reference_get_rate(self) }
+        set { image_sequence_reference_set_rate(self, newValue) }
+    }
+
+    public var frameZeroPadding: Int {
+        get { return Int(image_sequence_reference_get_frame_zero_padding(self)) }
+        set { image_sequence_reference_set_frame_zero_padding(self, Int32(newValue)) }
+    }
+
+    public var missingFramePolicy: MissingFramePolicy {
+        get { return MissingFramePolicy(rawValue: Int(image_sequence_reference_get_missing_frame_policy(self)))! }
+        set { image_sequence_reference_set_missing_frame_policy(self, Int32(newValue.rawValue)) }
+    }
+
+    public var endFrame: Int {
+        get { return Int(image_sequence_reference_end_frame(self)) }
+    }
+
+    public var numberOfImagesInSequence: Int {
+        get { return Int(image_sequence_reference_number_of_images_in_sequence(self)) }
+    }
+
+    public func frame(for time: RationalTime) throws -> Int {
+        return try Int(OTIOError.returnOrThrow { image_sequence_reference_frame_for_time(self, time.cxxRationalTime, &$0) })
+    }
+
+    public func targetURL(forImageNumber imageNumber: Int) throws -> String {
+        return try OTIOError.returnOrThrow { image_sequence_reference_target_url_for_image_number(self, Int32(imageNumber), &$0) }
+    }
+
+    public func presentationTime(forImageNumber imageNumber: Int) throws -> RationalTime {
+        return try RationalTime(OTIOError.returnOrThrow { image_sequence_reference_presentation_time_for_image_number(self, Int32(imageNumber), &$0) })
+    }
+
+    override internal init(_ cxxPtr: CxxSerializableObjectPtr) {
+        super.init(cxxPtr)
+    }
+}

--- a/Sources/swift/SerializableObject.swift
+++ b/Sources/swift/SerializableObject.swift
@@ -99,6 +99,7 @@ public class SerializableObject: CxxRetainer {
             creationFunctions["FreezeFrame"] = { FreezeFrame($0) }
             creationFunctions["Gap"] = { Gap($0) }
             creationFunctions["GeneratorReference"] = { GeneratorReference($0) }
+            creationFunctions["ImageSequenceReference"] = { ImageSequenceReference($0) }
             creationFunctions["Item"] = { Item($0) }
             creationFunctions["LinearTimeWarp"] = { LinearTimeWarp($0) }
             creationFunctions["Marker"] = { Marker($0) }

--- a/Tests/OpenTimelineIOTests/testImageSequenceReference.swift
+++ b/Tests/OpenTimelineIOTests/testImageSequenceReference.swift
@@ -1,0 +1,226 @@
+//
+//  testImageSequenceReference.swift
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+import XCTest
+@testable import OpenTimelineIO
+
+import Foundation
+
+class testImageSequenceReference: XCTestCase {
+
+    func testCreate() {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 30),
+                           duration: RationalTime(value: 60, rate: 30))
+        let dict = Metadata.Dictionary(arrayLiteral: ("custom", "bar"))
+
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         frameStep: 3,
+                                         rate: 30,
+                                         frameZeroPadding: 5,
+                                         missingFramePolicy: .hold,
+                                         availableRange: tr,
+                                         metadata: dict)
+
+        XCTAssertEqual(ref.targetURLBase, "file:///show/seq/shot/rndr/")
+        XCTAssertEqual(ref.namePrefix, "show_shot.")
+        XCTAssertEqual(ref.nameSuffix, ".exr")
+        XCTAssertEqual(ref.frameZeroPadding, 5)
+        XCTAssertEqual(ref.availableRange, tr)
+        XCTAssertEqual(ref.frameStep, 3)
+        XCTAssertEqual(ref.rate, 30)
+        XCTAssertEqual(ref.missingFramePolicy, .hold)
+        XCTAssertEqual(ref.metadata["custom"] as! String, "bar")
+    }
+
+    func testProperties() {
+        let ref = ImageSequenceReference()
+        ref.targetURLBase = "file:///show/seq/shot/rndr/"
+        ref.namePrefix = "show_shot."
+        ref.nameSuffix = ".exr"
+        ref.startFrame = 101
+        ref.frameStep = 2
+        ref.rate = 24
+        ref.frameZeroPadding = 4
+        ref.missingFramePolicy = .black
+
+        XCTAssertEqual(ref.targetURLBase, "file:///show/seq/shot/rndr/")
+        XCTAssertEqual(ref.namePrefix, "show_shot.")
+        XCTAssertEqual(ref.nameSuffix, ".exr")
+        XCTAssertEqual(ref.startFrame, 101)
+        XCTAssertEqual(ref.frameStep, 2)
+        XCTAssertEqual(ref.rate, 24)
+        XCTAssertEqual(ref.frameZeroPadding, 4)
+        XCTAssertEqual(ref.missingFramePolicy, .black)
+    }
+
+    func testNumberOfImagesInSequence() {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 24),
+                           duration: RationalTime(value: 48, rate: 24))
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         rate: 24,
+                                         availableRange: tr)
+
+        XCTAssertEqual(ref.numberOfImagesInSequence, 48)
+
+        ref.frameStep = 2
+        XCTAssertEqual(ref.numberOfImagesInSequence, 24)
+
+        ref.frameStep = 3
+        XCTAssertEqual(ref.numberOfImagesInSequence, 16)
+    }
+
+    func testEndFrame() {
+        let tr = TimeRange(startTime: RationalTime(value: 12, rate: 24),
+                           duration: RationalTime(value: 48, rate: 24))
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         startFrame: 101,
+                                         rate: 24,
+                                         frameZeroPadding: 4,
+                                         availableRange: tr)
+
+        XCTAssertEqual(ref.endFrame, 148)
+
+        ref.frameStep = 2
+        XCTAssertEqual(ref.endFrame, 148)
+    }
+
+    func testTargetURLForImageNumber() throws {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 24),
+                           duration: RationalTime(value: 48, rate: 24))
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         startFrame: 1,
+                                         frameStep: 1,
+                                         rate: 24,
+                                         frameZeroPadding: 4,
+                                         availableRange: tr)
+
+        XCTAssertEqual(ref.numberOfImagesInSequence, 48)
+        for i in 0..<ref.numberOfImagesInSequence {
+            let expected = String(format: "file:///show/seq/shot/rndr/show_shot.%04d.exr", i + 1)
+            XCTAssertEqual(try ref.targetURL(forImageNumber: i), expected)
+        }
+    }
+
+    func testNegativeFrameNumbers() throws {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 24),
+                           duration: RationalTime(value: 4, rate: 24))
+        let ref = ImageSequenceReference(targetURLBase: "",
+                                         namePrefix: "frame.",
+                                         nameSuffix: ".exr",
+                                         startFrame: -2,
+                                         frameStep: 1,
+                                         rate: 24,
+                                         frameZeroPadding: 4,
+                                         availableRange: tr)
+
+        XCTAssertEqual(ref.numberOfImagesInSequence, 4)
+        XCTAssertEqual(try ref.targetURL(forImageNumber: 0), "frame.-0002.exr")
+        XCTAssertEqual(try ref.targetURL(forImageNumber: 1), "frame.-0001.exr")
+        XCTAssertEqual(try ref.targetURL(forImageNumber: 2), "frame.0000.exr")
+        XCTAssertEqual(try ref.targetURL(forImageNumber: 3), "frame.0001.exr")
+    }
+
+    func testTargetURLWithMissingSlash() throws {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 24),
+                           duration: RationalTime(value: 48, rate: 24))
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         startFrame: 1,
+                                         frameStep: 1,
+                                         rate: 24,
+                                         frameZeroPadding: 4,
+                                         availableRange: tr)
+
+        XCTAssertEqual(try ref.targetURL(forImageNumber: 0),
+                       "file:///show/seq/shot/rndr/show_shot.0001.exr")
+    }
+
+    func testFrameForTime() throws {
+        let tr = TimeRange(startTime: RationalTime(value: 12, rate: 24),
+                           duration: RationalTime(value: 48, rate: 24))
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         startFrame: 1,
+                                         frameStep: 1,
+                                         rate: 24,
+                                         frameZeroPadding: 4,
+                                         availableRange: tr)
+
+        XCTAssertEqual(try ref.frame(for: tr.startTime), 1)
+        XCTAssertEqual(try ref.frame(for: RationalTime(value: 15, rate: 24)), 4)
+        XCTAssertEqual(try ref.frame(for: tr.endTimeInclusive()), 48)
+    }
+
+    func testFrameForTimeOutOfRange() {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 30),
+                           duration: RationalTime(value: 60, rate: 30))
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         rate: 30,
+                                         availableRange: tr)
+
+        XCTAssertThrowsError(try ref.frame(for: RationalTime(value: 73, rate: 30)))
+    }
+
+    func testPresentationTimeForImageNumber() throws {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 24),
+                           duration: RationalTime(value: 48, rate: 24))
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         startFrame: 1,
+                                         frameStep: 2,
+                                         rate: 24,
+                                         frameZeroPadding: 4,
+                                         availableRange: tr)
+
+        XCTAssertEqual(ref.numberOfImagesInSequence, 24)
+        for i in 0..<ref.numberOfImagesInSequence {
+            XCTAssertEqual(try ref.presentationTime(forImageNumber: i),
+                           RationalTime(value: Double(i * 2), rate: 24))
+        }
+    }
+
+    func testSerializeRoundtrip() throws {
+        let tr = TimeRange(startTime: RationalTime(value: 0, rate: 30),
+                           duration: RationalTime(value: 60, rate: 30))
+        let dict = Metadata.Dictionary(arrayLiteral: ("custom", "bar"))
+
+        let ref = ImageSequenceReference(targetURLBase: "file:///show/seq/shot/rndr/",
+                                         namePrefix: "show_shot.",
+                                         nameSuffix: ".exr",
+                                         frameStep: 3,
+                                         rate: 30,
+                                         frameZeroPadding: 5,
+                                         missingFramePolicy: .hold,
+                                         availableRange: tr,
+                                         metadata: dict)
+
+        let encoded = try ref.toJSON()
+        let decoded = try SerializableObject.fromJSON(string: encoded) as! ImageSequenceReference
+
+        XCTAssert(ref.isEquivalent(to: decoded))
+        XCTAssertEqual(decoded.targetURLBase, "file:///show/seq/shot/rndr/")
+        XCTAssertEqual(decoded.namePrefix, "show_shot.")
+        XCTAssertEqual(decoded.nameSuffix, ".exr")
+        XCTAssertEqual(decoded.frameZeroPadding, 5)
+        XCTAssertEqual(decoded.availableRange, tr)
+        XCTAssertEqual(decoded.frameStep, 3)
+        XCTAssertEqual(decoded.rate, 30)
+        XCTAssertEqual(decoded.missingFramePolicy, .hold)
+    }
+}


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Fixes Issue #82 

**Summarize your change.**

Support for ImageSequenceReference isn't available in the Swift bindings, this PR adds that support.

**Reference associated tests.**

`testImageSequenceReference.swift` has been added with 11 tests to cover this new implementation.

**Use of AI / LLM**

This code was written using an LLM.  The following are the details of that session.

### My Original Prompt
```
This folder is my fork of the OpenTimelineIO-Swift-Bindings repo.  I have added my own CLAUDE.md and SKILLS.md

Right now, ImageSequenceReference.1 is not supported in these Swift Bindings.  I have made a new branch "img-seq-ref" to implement ImageSequenceReference.1

Consult CLAUDE.md and SKILLS.md

Here is the documentation:  https://opentimelineio.readthedocs.io/en/stable/tutorials/otio-serialized-schema.html#imagesequencereference-1

```

### Environment
Claude Code
Model: Opus 4.8
Claude for Mac: Version 1.15962.2
See uploaded CLAUDE.md and SKILLS.md

---
### Start of Claude's Response

`ImageSequenceReference.1` is now implemented across all three layers, and the build and full test suite (75 tests, 0 failures) are green.

#### What I did

**1. Obj-C++ bridge** — `Sources/objc/include/opentimelineio.h` + `Sources/objc/opentimelineio.mm`
- Added `otio_new_image_sequence_reference()` constructor (and `#include <opentimelineio/imageSequenceReference.h>`).
- Added a `// MARK: - ImageSequenceReference` section wrapping every C++ member:
  - String props: `target_url_base`, `name_prefix`, `name_suffix`
  - Numeric props: `start_frame`, `frame_step`, `rate`, `frame_zero_padding`
  - Enum prop: `missing_frame_policy` (bridged as `int`, cast back to the C++ `MissingFramePolicy`)
  - Computed/derived: `end_frame`, `number_of_images_in_sequence`, and the three error-returning methods `frame_for_time`, `target_url_for_image_number`, `presentation_time_for_image_number` (using the `_AutoErrorHandler aeh(cxxErr)` pattern).

**2. Swift layer** — [ImageSequenceReference.swift](Sources/swift/ImageSequenceReference.swift)
- `public class ImageSequenceReference : MediaReference` with a nested `MissingFramePolicy: Int` enum (`error`/`hold`/`black`), modeled on `Track.NeighborGapPolicy`.
- Two convenience inits following the `ExternalReference`/`MediaReference` generic-metadata pattern, with C++-matching defaults (`startFrame: 1`, `frameStep: 1`, `rate: 1`, `frameZeroPadding: 0`, `missingFramePolicy: .error`).
- Computed properties for all fields; `endFrame`/`numberOfImagesInSequence` as get-only; the three error-returning methods as `throws` functions via `OTIOError.returnOrThrow`.
- Registered `"ImageSequenceReference"` in [SerializableObject.swift](Sources/swift/SerializableObject.swift)'s `WrapperCreator`.

**3. Tests** — [testImageSequenceReference.swift](Tests/OpenTimelineIOTests/testImageSequenceReference.swift)
- 11 tests covering construction, property round-trips, the enum, `endFrame`, `numberOfImagesInSequence`, `targetURL(forImageNumber:)` (including the missing-slash case), `frame(for:)` (including out-of-range throwing), `presentationTime(forImageNumber:)`, `testNegativeFrameNumbers`, and JSON serialize/deserialize round-trip. Expected values are taken from upstream's `test_image_sequence_reference.py`.

#### Notes worth flagging

- **Submodule wasn't initialized.** The `OpenTimelineIO/` C++ submodule was empty, so I ran `git submodule update --init --recursive` to get the headers needed to compile the bridge. (CLAUDE.md describes it as a checked-out reference repo.)
- **Test toolchain.** `swift test` failed with `no such module 'XCTest'` because `xcode-select` points at CommandLineTools. I ran the suite with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` (no global change). `swift build` works either way.
- I left your `CLAUDE.md` "Coverage status" section untouched — but it now lists `ImageSequenceReference.1` as missing, which is no longer true. Want me to move it into the "Bound" list?

One small API-design call I made: the conversion methods are named `frame(for:)`, `targetURL(forImageNumber:)`, and `presentationTime(forImageNumber:)` since there was no existing peer to copy. Easy to rename if you'd prefer something closer to the C++ `frame_for_time` / `target_url_for_image_number` naming.

### End of Claude's Response

---

I also used this new implementation to write out a couple of .otio test files containing image sequences.  Those imported correctly into: DaVinci Resolve, NukeStudio and RV.  I did have some issues with image sequences that have negative frame numbers, but those issues appear to be lack of support for negative frame numbers at the host application level and not my implementation.

Creating this as a Draft PR until we finalize our AI coding policy.

I did create my own CLAUDE.md and SKILLS.md for use with these Swift bindings.  I have uploaded them here for reference.
[CLAUDE.md](https://github.com/user-attachments/files/29600085/CLAUDE.md)
[SKILLS.md](https://github.com/user-attachments/files/29600086/SKILLS.md)
